### PR TITLE
Congo Spider

### DIFF
--- a/gazettemachine/spiders/congo.py
+++ b/gazettemachine/spiders/congo.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import urllib.parse as urlparse
+import scrapy
+import datetime
+
+from gazettemachine.items import GazetteMachineItem
+
+
+class CongoSpider(scrapy.Spider):
+    name = 'congo'
+    allowed_domains = ['sgg.cg']
+
+    def start_requests(self):
+        yield scrapy.Request('https://www.sgg.cg/fr/journal-officiel/le-journal-officiel.html', self.parse_ordinary)
+        yield scrapy.Request('https://www.sgg.cg/1/146/fr/journal-officiel/journaux-speciaux.html?page=0', self.parse_special)
+
+    def parse_ordinary(self, response):
+        for year in range(2020, datetime.date.today().year + 1):
+            css_string = f'ul#jos_{year} li#bloc_{year} a::attr(href)'
+            for href in response.css(css_string):
+                url = href.get()
+                if url.lower().endswith('.pdf'):
+                    url = response.urljoin(url)
+                    yield GazetteMachineItem(jurisdiction='cd', url=url)
+
+    def parse_special(self, response):
+        for href in response.css('div.collection.jos h4.titre_annee a::attr(href)'):
+            url = href.get()
+            if url.lower().endswith('.pdf'):
+                url = response.urljoin(url)
+                yield GazetteMachineItem(jurisdiction='cd', url=url)

--- a/gazettemachine/spiders/congo.py
+++ b/gazettemachine/spiders/congo.py
@@ -21,11 +21,11 @@ class CongoSpider(scrapy.Spider):
                 url = href.get()
                 if url.lower().endswith('.pdf'):
                     url = response.urljoin(url)
-                    yield GazetteMachineItem(jurisdiction='cd', url=url)
+                    yield GazetteMachineItem(jurisdiction='cg', url=url)
 
     def parse_special(self, response):
         for href in response.css('div.collection.jos h4.titre_annee a::attr(href)'):
             url = href.get()
             if url.lower().endswith('.pdf'):
                 url = response.urljoin(url)
-                yield GazetteMachineItem(jurisdiction='cd', url=url)
+                yield GazetteMachineItem(jurisdiction='cg', url=url)


### PR DESCRIPTION
This PR adds a spider for Congo gazettes.

### Sample list of PDF urls

Special edition URLs:
```
{"url": "https://www.sgg.cg/JO/2021/congo-jo-2021-05-sp-2.pdf"}
{"url": "https://www.sgg.cg/JO/2021/congo-jo-2021-05-sp-3.pdf"}
{"url": "https://www.sgg.cg/JO/2021/congo-jo-2021-03-sp.pdf"}
{"url": "https://www.sgg.cg/JO/2021/congo-jo-2021-02-sp.pdf"}
{"url": "https://www.sgg.cg/JO/2021/congo-jo-2021-01-sp.pdf"}
```

Ordinary edition URLs:
```
{"url": "https://www.sgg.cg/JO/2020/congo-jo-2020-52.pdf"}
{"url": "https://www.sgg.cg/JO/2020/congo-jo-2020-51.pdf"}
{ "url": "https://www.sgg.cg/JO/2020/congo-jo-2020-50.pdf"}
{"url": "https://www.sgg.cg/JO/2020/congo-jo-2020-49.pdf"}
{"url": "https://www.sgg.cg/JO/2020/congo-jo-2020-48.pdf"}
{"url": "https://www.sgg.cg/JO/2020/congo-jo-2020-47.pdf"}
```

ref [GazetteMachine #57](https://github.com/laws-africa/gazettemachine/issues/57)

