### PR TITLE
Rwanda Scraper Fix

### DIFF
--- a/gazettemachine/spiders/govrw.py
+++ b/gazettemachine/spiders/govrw.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-import urllib.parse as urlparse
 import scrapy
-import datetime
-
 
 from gazettemachine.items import GazetteMachineItem
 
@@ -16,7 +13,9 @@ class GovRWSpider(scrapy.Spider):
         # year, month and gazette listing pages all have the same format
         for href in response.css('.tx-filelist table td a::attr(href)'):
             url = href.get()
-            if url.lower().endswith('.pdf'):
+
+            # base file URL https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=31203&token=...
+            if 'index.php?eID=dumpFile&t=f' in url:
                 url = response.urljoin(url)
                 yield GazetteMachineItem(jurisdiction='rw', url=url)
             else:


### PR DESCRIPTION
File URLs have changed to the format `https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=31203&token=...` so now we check for `index.php?eID=dumpFile&t=f` in the URL to identify file download URLs

Sample output:
```
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=11000&token=84f1ddaf8a0c20af675ae8bb6ecde5ed81bbcb91"}
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=11000&token=84f1ddaf8a0c20af675ae8bb6ecde5ed81bbcb91"}
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=10124&token=2bb8ad6f12b1b7f474bd7e171c5a9ee3329cde62"}
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=10124&token=2bb8ad6f12b1b7f474bd7e171c5a9ee3329cde62"}
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=10123&token=6592540817d921ee2f478e932b8804311338f85a"}
{"jurisdiction": "rw", "url": "https://www.minijust.gov.rw/index.php?eID=dumpFile&t=f&f=10123&token=6592540817d921ee2f478e932b8804311338f85a"}
```


ref [laws-africa/gazettemachine #86](https://github.com/laws-africa/gazettemachine/issues/86)